### PR TITLE
💚 fix gas-report CI workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions: write-all
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3


### PR DESCRIPTION
Add missing permissions to read the `gas-report` file generated on the main branch.