### PR TITLE
🔧 increase the number of optimisation runs

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -10,7 +10,7 @@ fuzz = { runs = 1_000 }
 gas_reports = ["*"]
 libs = ["lib"]
 optimizer = true
-optimizer_runs = 10_000
+optimizer_runs = 100_000
 out = "out"
 script = "script"
 solc = "0.8.19"


### PR DESCRIPTION
By moving the number of optimization runs from _10_000_ to _100_000_, those implementations are on average cheaper by:
- `ECDSA256r1`: 25.10%
- `ECDSA256r1Precompute`: 19.06%

The tradeoff is that both contracts are now more expensive to deploy by ~**25/30%**.

At this point, it is an acceptable tradeoff, as the except users will have fewer accounts than before in this new 4337 world. Let's see how it goes.