### PR TITLE
🔧 improve foundry configuration

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -23,6 +23,11 @@ remappings = [
     "forge-std/=lib/forge-std/src/",
     "@prb-test/=lib/prb-test/src/",
 ]
+extra_output_files = ["metadata", "ir", "evm.assembly"]
+gas_reports_ignore = [
+    "ImplementationECDSA256r1",
+    "ImplementationECDSA256r1Precompute",
+]
 
 [profile.ci]
 fuzz = { runs = 10_000 }


### PR DESCRIPTION
- Output extra files during compilation (metadata, ir, emv.assembly)
- Hide from gas report the wrapper around the implementations