### PR TITLE
♻️ switch `verify` function to internal

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -24,10 +24,6 @@ remappings = [
     "@prb-test/=lib/prb-test/src/",
 ]
 extra_output_files = ["metadata", "ir", "evm.assembly"]
-gas_reports_ignore = [
-    "ImplementationECDSA256r1",
-    "ImplementationECDSA256r1Precompute",
-]
 
 [profile.ci]
 fuzz = { runs = 10_000 }

--- a/src/ECDSA256PrecomputeInternal.sol
+++ b/src/ECDSA256PrecomputeInternal.sol
@@ -148,7 +148,7 @@ library ECDSA256r1PrecomputeInternal {
     /// @param precomputedOffset The **offset** where the precomputed points starts in the bytecode
     /// @return True if the signature is valid, false otherwise.
     /// @dev Note the required interactions with the precompled contract can revert the transaction
-    function verify(bytes32 message, uint256 r, uint256 s, uint256 precomputedOffset) external returns (bool) {
+    function verify(bytes32 message, uint256 r, uint256 s, uint256 precomputedOffset) internal returns (bool) {
         // check the validity of the signature
         if (r == 0 || r >= n || s == 0) {
             return false;

--- a/src/ECDSA256r1.sol
+++ b/src/ECDSA256r1.sol
@@ -198,7 +198,7 @@ library ECDSA256r1 {
     /// @param qy The y value of the public key used for the signature
     /// @return bool True if the signature is valid, false otherwise
     /// @dev Note the required interactions with the precompled contract can revert the transaction
-    function verify(bytes32 message, uint256 r, uint256 s, uint256 qx, uint256 qy) external returns (bool) {
+    function verify(bytes32 message, uint256 r, uint256 s, uint256 qx, uint256 qy) internal returns (bool) {
         // check the validity of the signature
         if (r == 0 || r >= n || s == 0 || s >= n) {
             return false;

--- a/src/ECDSA256r1Precompute.sol
+++ b/src/ECDSA256r1Precompute.sol
@@ -188,7 +188,7 @@ library ECDSA256r1Precompute {
     ///        to be functional.
     /// @return True if the signature is valid, false otherwise.
     /// @dev Note the required interactions with the precompled contract can revert the transaction
-    function verify(bytes32 message, uint256 r, uint256 s, address precomputedTable) external returns (bool) {
+    function verify(bytes32 message, uint256 r, uint256 s, address precomputedTable) internal returns (bool) {
         // check the validity of the signature
         if (r == 0 || r >= n || s == 0 || s >= n) {
             return false;


### PR DESCRIPTION
Making these functions external or public by default force them to be used in a specify way, this is probably to much opinionated for this repository