### PR TITLE
👷 create CI workflow for test-coverage 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,3 +64,48 @@ jobs:
           # delete the comment in case changes no longer impact gas costs
           delete: ${{ !steps.gas_diff.outputs.markdown }}
           message: ${{ steps.gas_diff.outputs.markdown }}
+
+  coverage:
+    needs: ["test"]
+    permissions: write-all
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Check out the repo"
+        uses: "actions/checkout@v3"
+        with:
+          submodules: "recursive"
+
+      - name: "Install Foundry"
+        uses: "foundry-rs/foundry-toolchain@v1"
+
+      # required to install our private package from Github Packages
+      - name: Authenticate with GitHub Packages
+        run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > ~/.npmrc
+
+      # needed because the precomputation scripts used by the ffi tests is a JS dependency
+      - name: Install the Node.js dependencies
+        run: npm ci
+
+      - name: Setup lcov
+        uses: hrishikesh-kadam/setup-lcov@v1
+
+      - name: "Generate the coverage report"
+        # contracts in the test/ and script/ directory are excluded fron the report
+        # the precompute internal version of the library is also excluded from the report as
+        # it is highly experimental and to meant to be used at all
+        run: "forge coverage --report lcov && lcov --remove lcov.info \
+          -o lcov.info 'test/*' 'script/*' 'src/ECDSA256PrecomputeInternal.sol'"
+
+      - name: "Add coverage summary"
+        run: |
+          echo "## Coverage result" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Passed" >> $GITHUB_STEP_SUMMARY
+
+      - name: Report code coverage
+        uses: zgosalvez/github-actions-report-lcov@v3
+        with:
+          coverage-files: lcov.info
+          minimum-coverage: 80
+          artifact-name: code-coverage-report
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          update-comment: true

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ docs
 gasreport.ansi
 .gas-snapshot*
 
+# coverage output
+coverage

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,3 +1,3 @@
 {
-  "filter_paths": "lib|test"
+  "filter_paths": "lib|test|script"
 }

--- a/src/ECDSA256PrecomputeInternal.sol
+++ b/src/ECDSA256PrecomputeInternal.sol
@@ -3,6 +3,8 @@ pragma solidity >=0.8.19 <0.9.0;
 
 import { Curve, p, n, MINUS_2, MODEXP_PRECOMPILE } from "./utils/ECDSA.sol";
 
+// >>>>>>>>>>>>>>>>>>>>>>> DO NOT USE ME!!!!!!! <<<<<<<<<<<<<<<<<<<<<<<
+
 /// @title ECDSA256r1PrecomputeInternal
 /// @notice This library is for ECDSA verification using a precomputed table of multiples of P and Q. The Shamir's
 ///         Secret Sharing scheme is used in 8 dimensions. The precomputed table must be stored **in** the bytecode of

--- a/test/utils/ECDSA.t.sol
+++ b/test/utils/ECDSA.t.sol
@@ -76,7 +76,6 @@ contract ECDSATest is StdUtils, PRBTest {
         assertEq(y1, 0);
     }
 
-    // TODO: Test the assembly branch of the `zzAddN` function
     function test_zzAddNZero() external {
         zzPoint memory point1 = zzPoint(0x1, 0x00, 0x3, 0x4);
         Point memory point2 = Point(0x5, 0x6);
@@ -88,6 +87,21 @@ contract ECDSATest is StdUtils, PRBTest {
         assertEq(y, point2.y);
         assertEq(zz, 1);
         assertEq(zzz, 1);
+    }
+
+    // TODO: This test is shit, it's a horrible regression test. Rework it using fuzzing
+    //       for testing the assembly block of the `zzAddN` function
+    function test_zzAddN() external {
+        zzPoint memory point1 = zzPoint(0x1, 0x06, 0x3, 0x4);
+        Point memory point2 = Point(0x5, 0x99);
+
+        (uint256 x, uint256 y, uint256 zz, uint256 zzz) =
+            implementation.zzAddN(point1.x, point1.y, point1.zz, point1.zzz, point2.x, point2.y);
+
+        assertEq(x, 364_100);
+        assertEq(y, 0xffffffff00000001000000000000000000000000fffffffffffffffff2dacaaf);
+        assertEq(zz, 588);
+        assertEq(zzz, 10_976);
     }
 
     // TODO: Test the assembly branch of the `zzDouble` function (for real)


### PR DESCRIPTION
This new workflow run the test-coverage script. The coverage is posted
as a comment on the PR. The workflow is configured to succeed if the
coverage is above 80%.
The internal precompile variant is excluded from the coverage report as
it is highly experimental and not expected to be used, even in dev mode,
at this point

Fixes #17 