### PR TITLE
🔧 adopt the naming convention for tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,9 @@ jobs:
 
       # TODO: Rework the job to correctly print the output of the test command
       - name: Run tests with gas reporting
-        run: forge test --gas-report > gasreport.ansi
+        run:
+          forge test --gas-report --no-match-test "test.*_ReportSkip|test_RevertWhen|testFuzz_RevertWhen" >
+          gasreport.ansi
         env:
           # make fuzzing semi-deterministic to avoid noisy gas cost estimation
           # due to non-deterministic fuzzing (but still use pseudo-random fuzzing seeds)

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ These gas reports were produced using the `0.8.19` version of the Solidity compi
 specifically for the
 [`0.3.1`](https://github.com/0x90d2b2b7fb7599eebb6e7a32980857d8/secp256r1-verify/releases/tag/v0.3.1) version of the
 library. The library version corresponds to commit
-[5436b12](https://github.com/0x90d2b2b7fb7599eebb6e7a32980857d8/secp256r1-verify/commit/5436b12f40e3cb5d0f593709067b22054e4164b8).
+[4d0716f](https://github.com/0x90d2b2b7fb7599eebb6e7a32980857d8/secp256r1-verify/commit/4d0716fc6fd14a92488442e1dd0c18bb2c24ff41).
 
 > ℹ️ If you import the library into your project, we strongly recommend you to enable the optimizer with 100k in order
 > to have the best gas consumption.

--- a/README.md
+++ b/README.md
@@ -183,28 +183,30 @@ scripts are expected to be run using the `forge script` command.
 
 ## Gas reports
 
-These gas reports were produced using the `0.8.19` version of the Solidity compiler, specifically for the
-[`0.3.0`](https://github.com/0x90d2b2b7fb7599eebb6e7a32980857d8/secp256r1-verify/releases/tag/v0.3.0) version of the
+These gas reports were produced using the `0.8.19` version of the Solidity compiler (with 100k optimizer runs),
+specifically for the
+[`0.3.1`](https://github.com/0x90d2b2b7fb7599eebb6e7a32980857d8/secp256r1-verify/releases/tag/v0.3.1) version of the
 library. The library version corresponds to commit
 [5436b12](https://github.com/0x90d2b2b7fb7599eebb6e7a32980857d8/secp256r1-verify/commit/5436b12f40e3cb5d0f593709067b22054e4164b8).
 
+> ℹ️ If you import the library into your project, we strongly recommend you to enable the optimizer with 100k in order
+> to have the best gas consumption.
+
 ### The traditional implementation [🔗](#1️⃣-the-traditional-implementation)
 
-|                 |                 |        |        |        |
-| --------------- | --------------- | ------ | ------ | ------ |
 | Deployment Cost | Deployment Size |        |        |        |
-| 978643          | 4946            |        |        |        |
+| --------------- | --------------- | ------ | ------ | ------ |
+| 1002641         | 5040            |        |        |        |
 | Function Name   | min             | avg    | median | max    |
-| verify          | 448             | 110273 | 197391 | 212108 |
+| verify          | 192620          | 202959 | 202905 | 210079 |
 
 ### The external precomputed points implementation [🔗](#2️⃣-the-external-precomputed-points-implementation-recommended)
 
-|                 |                 |       |        |       |
-| --------------- | --------------- | ----- | ------ | ----- |
 | Deployment Cost | Deployment Size |       |        |       |
-| 649708          | 3303            |       |        |       |
+| --------------- | --------------- | ----- | ------ | ----- |
+| 675908          | 3408            |       |        |       |
 | Function Name   | min             | avg   | median | max   |
-| verify          | 472             | 44794 | 59185  | 75396 |
+| verify          | 74589           | 75378 | 75507  | 75507 |
 
 Although the prerequisites for implementing this approach are more complex, the gas cost for the verification process is
 over three times less expensive than the traditional method.

--- a/makefile
+++ b/makefile
@@ -74,7 +74,9 @@ forge-coverage:
 
 .PHONY: forge-test-gas
 forge-test-gas:
-	@runcmd forge test --gas-report
+	@runcmd forge test --gas-report --no-match-test "test.*_ReportSkip|test_RevertWhen|testFuzz_RevertWhen"
+# the regexp catches the tests that start with `testFuzz_RevertWhen`, `test_RevertWhen` or end with `_ReportSkip`
+# stick to this convention to avoid running the gas report on tests that are not meant to be run
 
 .PHONY: forge-clean
 clean:

--- a/test/ecdsa256r1.t.sol
+++ b/test/ecdsa256r1.t.sol
@@ -120,7 +120,7 @@ contract Ecdsa256r1Test is PRBTest {
         assertEq(_4P_res1, _4P_res3);
     }
 
-    function test_MulMullAddMultipleBy0Fail(uint256 q0, uint256 q1) public {
+    function test_MulMullAddMultipleBy0Fail_ReportSkip(uint256 q0, uint256 q1) public {
         uint256 res = implementation.mulmuladd(q0, q1, 0, 0);
         assertEq(res, 0);
     }
@@ -131,12 +131,12 @@ contract Ecdsa256r1Test is PRBTest {
     }
 
     // test invalid vectors, all assert shall be false
-    function test_VerifyInvalidVectorsIncorrect() public {
+    function test_VerifyInvalidVectorsIncorrect_ReportSkip() public {
         _validateInvariantEcMulMulAdd(false);
     }
 
     // test invalid vectors, all assert shall be false
-    function test_VerifySignatureValidity() public {
+    function test_VerifySignatureValidity_ReportSkip() public {
         // expect to fail because rs[0] == 0
         bool isValid = implementation.verify(bytes32("hello"), uint256(0), uint256(1), uint256(1), uint256(1));
         assertFalse(isValid);

--- a/test/ecdsa256r1Precomput.t.sol
+++ b/test/ecdsa256r1Precomput.t.sol
@@ -167,7 +167,7 @@ contract Ecdsa256r1PrecomputTest is StdUtils, PRBTest {
 
     /// @notice Test function for verifying invalid vectors
     /// @dev Ensures that all the invalid test vectors are not working
-    function test_VerifyInvalidVectorsIncorrect() external _preparePrecomputeTable {
+    function test_VerifyInvalidVectorsIncorrect_ReportSkip() external _preparePrecomputeTable {
         // load the wycheproof test vectors
         TestVectors memory testVectors = invalidVectors;
 
@@ -183,7 +183,7 @@ contract Ecdsa256r1PrecomputTest is StdUtils, PRBTest {
 
     /// @notice Test function for verifying incorrect signatures
     /// @dev Ensures that incorrect signatures are not valid
-    function test_VerifyIncorrectSignatureFail() external _preparePrecomputeTable {
+    function test_VerifyIncorrectSignatureFail_ReportSkip() external _preparePrecomputeTable {
         // expect to fail because rs[0] == 0
         bool isValid = implementation.verify(bytes32("hello"), uint256(0), uint256(1), precomputeAddress);
         assertFalse(isValid);
@@ -211,7 +211,7 @@ contract Ecdsa256r1PrecomputTest is StdUtils, PRBTest {
 
     /// @notice Test function for verifying incorrect addresses
     /// @dev Ensures that incorrect addresses fail verification (0x00 + precompile addresses + some extra empty ones)
-    function test_VerifyIncorectAddressesFail() external _preparePrecomputeTable {
+    function test_VerifyIncorectAddressesFail_ReportSkip() external _preparePrecomputeTable {
         // get a valid test vector (message, signature)
         (uint256 r, uint256 s, bytes32 message) = _getTestVector(validVectors.fixtures, "1");
 

--- a/test/utils/ECDSA.t.sol
+++ b/test/utils/ECDSA.t.sol
@@ -114,7 +114,7 @@ contract ECDSATest is StdUtils, PRBTest {
     }
 
     // TODO: Test the unchecked branch of the `affIsOnCurve` function
-    function test_affIsOnCurveInvalidPoints() external {
+    function test_affIsOnCurveInvalidPoints_ReportSkip() external {
         // expect to fail because x == 0
         bool isOnCurve = implementation.affIsOnCurve(0, 2);
         assertFalse(isOnCurve);

--- a/test/utils/secp256r1.t.sol
+++ b/test/utils/secp256r1.t.sol
@@ -32,7 +32,7 @@ contract Secp256r1Test is StdUtils, PRBTest {
      * inverse is equal to 1 mod n.
      */
     /// @param valueToInvert The value to invert.
-    function test_Fuzz_InVmodn(uint256 valueToInvert) public {
+    function testFuzz_InVmodn(uint256 valueToInvert) public {
         // bound the fuzzed value between 1 and n-1
         valueToInvert = bound(valueToInvert, 1, n - 1);
 
@@ -47,7 +47,7 @@ contract Secp256r1Test is StdUtils, PRBTest {
      * inverse is equal to 1 mod p.
      */
     /// @param valueToInvert The value to invert.
-    function test_Fuzz_InVmodp(uint256 valueToInvert) public {
+    function testFuzz_InVmodp(uint256 valueToInvert) public {
         // bound the fuzzed value between 1 and p-1
         valueToInvert = bound(valueToInvert, 1, p - 1);
 


### PR DESCRIPTION
By adopting the convention, we blacklist non-relevant tests from the gas report. That produces a more realistic and accurate report. In addition, I decide to use the suffix `_ReportSkip` to blacklist tests that do not expect to revert but are not relevant to the gas report because they test a failure case. Helpful and relevant in the case of a library that returns a boolean that is supposed to return true when correctly used.

In this PR, gas reports are updated after we filtered the non-relevant tests.