### PR TITLE
🐛 Add missing T1 assignments

### DIFF
--- a/src/ECDSA256r1.sol
+++ b/src/ECDSA256r1.sol
@@ -129,7 +129,8 @@ library ECDSA256r1 {
                                 T2 := mulmod(T1, T1, p)
                                 // S = X1*V
                                 T3 := mulmod(X, T2, p)
-
+                                // W=UV
+                                T1 := mulmod(T1, T2, p)
                                 y2 := addmod(X, zz, p)
                                 let TT1 := addmod(X, sub(p, zz), p)
                                 // X-ZZ)(X+ZZ)

--- a/src/ECDSA256r1Precompute.sol
+++ b/src/ECDSA256r1Precompute.sol
@@ -129,6 +129,8 @@ library ECDSA256r1Precompute {
                             T2 := mulmod(T1, T1, p)
                             // S = X1*V
                             let T3 := mulmod(X, T2, p)
+                            // W=UV
+                            T1 := mulmod(T1, T2, p)
                             y2 := addmod(X, zz, p)
                             let TT1 := addmod(X, sub(p, zz), p)
                             //(X-ZZ)(X+ZZ)


### PR DESCRIPTION
As @obatirou figured out, one T1 assignment was missing in a flow that occurs very rarely. This is a rare but serious issue with the library. Fixed now.