### PR TITLE
🔖 bump to 0.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@0x90d2b2b7fb7599eebb6e7a32980857d8/secp256r1-verify",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@0x90d2b2b7fb7599eebb6e7a32980857d8/secp256r1-verify",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "devDependencies": {
         "@0x90d2b2b7fb7599eebb6e7a32980857d8/secp256r1-computation": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@0x90d2b2b7fb7599eebb6e7a32980857d8/secp256r1-verify",
   "description": "A solidity library to verify a secp256r1 signature",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "contributors": [
     {
       "name": "qd-qd",


### PR DESCRIPTION
This version, among other minor things, includes the fix pushed by @nlordell in the [FCL repository](https://github.com/rdubois-crypto/FreshCryptoLib/pull/52).